### PR TITLE
Fix pymodbus dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 include_package_data = True
 python_requires = >= 3.8
 install_requires =
-    pymodbus >= 3.0.0
+    pymodbus >= 3.5.0
     pyserial-asyncio >= 0.6.0
 
 [options.packages.find]

--- a/src/alfen_eve_modbus_tcp/__init__.py
+++ b/src/alfen_eve_modbus_tcp/__init__.py
@@ -89,7 +89,7 @@ MODBUS_SLAVE_MAX_CURRENT_ENABLE_MAP = {
 class AlfenEve:
 
     model = "Alfen Eve"
-    wordorder = Endian.Big
+    wordorder = Endian.BIG
 
     def __init__(
         self, host=False, port=False,
@@ -134,7 +134,7 @@ class AlfenEve:
             if len(result.registers) != length:
                 continue
 
-            return BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big, wordorder=self.wordorder)
+            return BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG, wordorder=self.wordorder)
 
         return None
 
@@ -142,7 +142,7 @@ class AlfenEve:
         return self.client.write_registers(address=address, values=value, slave=slave)
 
     def _encode_value(self, data, dtype):
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=self.wordorder)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=self.wordorder)
 
         try:
             if dtype == registerDataType.UINT16:
@@ -309,7 +309,7 @@ class CarCharger(AlfenEve):
 
     def __init__(self, *args, **kwargs):
         self.model = "Car Charger"
-        self.wordorder = Endian.Big
+        self.wordorder = Endian.BIG
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
pymodbus [3.5](https://github.com/pymodbus-dev/pymodbus/releases/tag/v3.5.0) (currently at 3.6.8) introduce enums for, amongst others, endian values. To be consistent, we need to bump its requires value.

Source: https://github.com/pymodbus-dev/pymodbus/pull/1743

N.B. solaredge_modbus also [fixed ](https://github.com/nmakel/solaredge_modbus/issues/83)this last fall.